### PR TITLE
Fix/min flow/residue overflow

### DIFF
--- a/src/graph/float_weight.rs
+++ b/src/graph/float_weight.rs
@@ -1,6 +1,7 @@
 //!
 //! FloatWeight
 //!
+use fnv::FnvHashSet as HashSet;
 use petgraph::prelude::*;
 
 pub trait FloatWeight {
@@ -59,6 +60,36 @@ pub fn is_cycle<N, E>(graph: &DiGraph<N, E>, edges: &[EdgeIndex]) -> bool {
 
         v1 == v2
     })
+}
+
+///
+/// determine if the path (= a list of nodes) is node-simple
+///
+pub fn is_node_simple<N, E>(graph: &DiGraph<N, E>, nodes: &[NodeIndex]) -> bool {
+    let mut used: HashSet<NodeIndex> = HashSet::default();
+    for &node in nodes {
+        if used.contains(&node) {
+            return false;
+        } else {
+            used.insert(node);
+        }
+    }
+    return true;
+}
+
+///
+/// determine if the path (= a list of edges) is edge-simple
+///
+pub fn is_edge_simple<N, E>(graph: &DiGraph<N, E>, edges: &[EdgeIndex]) -> bool {
+    let mut used: HashSet<EdgeIndex> = HashSet::default();
+    for &edge in edges {
+        if used.contains(&edge) {
+            return false;
+        } else {
+            used.insert(edge);
+        }
+    }
+    return true;
 }
 
 /// Find the minimum weight edge among all parallel edges between v and w

--- a/src/graph/min_mean_weight_cycle.rs
+++ b/src/graph/min_mean_weight_cycle.rs
@@ -8,7 +8,7 @@
 //! * https://walkccc.me/CLRS/Chap24/Problems/24-5/
 //!
 use super::FloatWeight;
-use crate::graph::float_weight::node_list_to_edge_list;
+use crate::graph::float_weight::{is_node_simple, node_list_to_edge_list};
 use petgraph::prelude::*;
 use petgraph::visit::{VisitMap, Visitable};
 pub mod edge_cond;
@@ -194,6 +194,7 @@ pub fn find_negative_cycle<N, E: FloatWeight>(
     match find_minimum_mean_weight_cycle(graph, source) {
         Some((cycle, mean_weight)) => {
             if mean_weight < 0.0 {
+                assert!(is_node_simple(graph, &cycle));
                 Some(cycle)
             } else {
                 None

--- a/src/min_flow/residue.rs
+++ b/src/min_flow/residue.rs
@@ -9,7 +9,8 @@ use super::utils::draw;
 use super::{Cost, FlowRate};
 use crate::graph::bellman_ford::HasEpsilon;
 use crate::graph::float_weight::{
-    edge_cycle_to_node_cycle, is_cycle, is_negative_cycle, node_list_to_edge_list, total_weight,
+    edge_cycle_to_node_cycle, is_cycle, is_edge_simple, is_negative_cycle, node_list_to_edge_list,
+    total_weight,
 };
 use crate::graph::min_mean_weight_cycle::edge_cond::find_negative_cycle_with_edge_cond;
 use crate::graph::min_mean_weight_cycle::{find_negative_cycle, find_negative_edge_cycle};
@@ -337,6 +338,7 @@ fn update_flow_in_residue_graph(flow: &Flow, rg: &ResidueGraph) -> Option<Flow> 
         Some(edges) => {
             // check if this is actually negative cycle
             assert!(is_cycle(&rg, &edges), "the cycle was not valid");
+            assert!(is_edge_simple(&rg, &edges), "the cycle is not edge-simple");
             assert!(
                 is_negative_cycle(&rg, &edges),
                 "total weight of the found negative cycle is not negative. edges={:?} total_weight={}",


### PR DESCRIPTION
residue graph上のcycleでflowを書き換える時、順番が悪いとusize上の0-1が生じてoverflowしうる。
与えられた辺のリストが本当にresidue graph上のcycleならば、最終的なflowにはoverflowした結果は残らないはず(一時的に-1等が生じても、最終的には+1が加わってusize範囲内の値に収まるはず)

* wrapping関数を使うように変更
* cycleの性質のチェックを追加